### PR TITLE
Fixed variable scope error that prevented correct dragging handling

### DIFF
--- a/static/js/jquery.switch.js
+++ b/static/js/jquery.switch.js
@@ -12,7 +12,8 @@
               , $label
               , myClasses = ""
               , classes = $element.attr('class')
-              , color;
+              , color
+              , moving;
 
             $.each(['switch-mini', 'switch-small', 'switch-large'], function (i, el) {
               if (classes.indexOf(el) >= 0)
@@ -88,8 +89,8 @@
             });
 
             $element.find('label').on('mousedown touchstart', function (e) {
-              var $this = $(this)
-                , moving = false;
+              var $this = $(this);
+              moving = false;
 
               e.preventDefault();
               e.stopImmediatePropagation();


### PR DESCRIPTION
The variable `moving` was declared in an incorrect place. That broke the correct handling of the dragging (i.e.: when the handler is dragged for less than the half of the whole switch the state should not change)
