### PR TITLE
'switch' is a reserved keyword in ie8

### DIFF
--- a/static/js/jquery.switch.js
+++ b/static/js/jquery.switch.js
@@ -1,7 +1,7 @@
 !function ($) {
   "use strict";
 
-  $.fn.switch = function (method) {
+  $.fn['switch'] = function (method) {
     var methods = {
       init:function () {
         this.each(function () {
@@ -205,5 +205,5 @@
 }(jQuery);
 
 $(function () {
-  $('.switch').switch();
+  $('.switch')['switch']();
 });


### PR DESCRIPTION
'switch' is a reserved keyword in Internet Explorer 8, example project with the fix applied: http://ajmm.org/phpmd/
