### PR TITLE
Fixed an issue with disabled checkboxes.

### DIFF
--- a/static/js/bootstrapSwitch.js
+++ b/static/js/bootstrapSwitch.js
@@ -139,7 +139,7 @@
 
               $this.closest('div').removeClass('switch-animate');
 
-              if ($this.closest('.switch').is('.deactivate'))
+              if ($this.closest('.has-switch').is('.deactivate'))
                 $this.unbind('click');
               else {
                 $this.on('mousemove touchmove', function (e) {


### PR DESCRIPTION
updated 
"in  if ($this.closest('.switch').is('.deactivate'))" 
to be 
"in  if ($this.closest('.has-switch').is('.deactivate'))".
because if anyone initialized the plugin to an element that doesn't have switch class and the inner checkbox is disabled, it will be dimmed but still working because it won't find the ".switch" class in closest selector.
