### PR TITLE
Added rules to remove rounded borders if input is prepended or appended

### DIFF
--- a/static/stylesheets/bootstrapSwitch.css
+++ b/static/stylesheets/bootstrapSwitch.css
@@ -357,3 +357,26 @@
 .has-switch span.switch-danger.active {
   background-color: #e9322d \9;
 }
+
+
+/*Allows the use of append extensions on a switch*/
+.input-prepend .switch-left,
+.input-prepend .has-switch {
+  -webkit-border-top-left-radius: 0 !important;
+  -webkit-border-bottom-left-radius: 0 !important;
+  -moz-border-top-left-radius: 0 !important;
+  -moz-border-bottom-left-radius: 0 !important;
+      border-top-left-radius:0 !important;
+      border-bottom-left-radius:0 !important;
+}
+
+/*Allows the use of prepend extensions on a switch*/
+.input-append .switch-left,
+.input-append .has-switch {
+  -webkit-border-top-right-radius: 0 !important;
+  -webkit-border-bottom-right-radius: 0 !important;
+  -moz-border-top-right-radius: 0 !important;
+  -moz-border-bottom-right-radius: 0 !important;
+      border-top-right-radius:0 !important;
+      border-bottom-right-radius:0 !important;
+}


### PR DESCRIPTION
Just added two rules to the stylesheet so the rounded border is removed when an appended or prepended input extension is added.

Haven't updated the Less rules.

http://twitter.github.io/bootstrap/base-css.html#forms

![switch-example](https://f.cloud.github.com/assets/1098227/513548/1a19c834-be41-11e2-973c-2969aa599057.jpg)
