### PR TITLE
Bind a reset event for form reset

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -314,7 +314,7 @@ $('#disable-switch').bootstrapSwitch('setActive', false);  // true || false</pre
 
 <div class="row-fluid">
     <div class="span12">
-        <h3>Form <small>- try to use tab and space</small></h3>
+        <h3>Form <small>- try to use tab, space and reset button</small></h3>
 
         <div class="bs-docs-example">
             <form class="form-horizontal span8 offset2">
@@ -343,6 +343,10 @@ $('#disable-switch').bootstrapSwitch('setActive', false);  // true || false</pre
                         </div>
                     </div>
                 </div>
+
+                <div class="form-actions">
+                    <button type="reset" class="btn btn-inverse">Reset</button>
+                </div>
             </form>
             <div class="clearfix"></div>
         </div>
@@ -369,6 +373,9 @@ $('#disable-switch').bootstrapSwitch('setActive', false);  // true || false</pre
                 &lt;input id="notification2" type="checkbox" />
             &lt;/div>
         &lt;/div>
+    &lt;/div>
+    &lt;div class="form-actions">
+        &lt;button type="reset" class="btn btn-inverse">Reset&lt;/button>
     &lt;/div>
 &lt;/form></pre>
     </div>

--- a/static/js/bootstrap-switch.js
+++ b/static/js/bootstrap-switch.js
@@ -249,7 +249,9 @@
         return $(this).find('input:checkbox').is(':checked');
       },
       destroy: function () {
-        var $div = $(this).find('div')
+        var $element = $(this)
+          , $div = $element.find('div')
+          , $form = $element.closest('form')
           , $checkbox;
 
         $div.find(':not(input:checkbox)').remove();
@@ -258,6 +260,11 @@
         $checkbox.unwrap().unwrap();
 
         $checkbox.unbind('change');
+
+        if ($form) {
+          $form.unbind('reset');
+          $form.removeData('bootstrapSwitch');
+        }
 
         return $checkbox;
       }


### PR DESCRIPTION
Before this patch, bootstrapSwitch will keep the status after user click the RESET button.

Now, bootstrapSwitch will be listen the RESET event of form and reset to correct value.
