### PR TITLE
Add missing semicolon

### DIFF
--- a/static/js/bootstrap-switch.js
+++ b/static/js/bootstrap-switch.js
@@ -320,7 +320,7 @@
         var $label = $element.find("label");
         $.each(['switch-mini', 'switch-small', 'switch-large'], function (i, el) {
           if (el !== value) {
-            $switchLeft.removeClass(el)
+            $switchLeft.removeClass(el);
             $switchRight.removeClass(el);
             $label.removeClass(el);
           } else {


### PR DESCRIPTION
In minified js throws an error - Uncaught SyntaxError: Unexpected token (Chrome for Mac Version 28.0.1500.95)
