### PR TITLE
Changing data-icon in favor of data-label-icon

### DIFF
--- a/static/js/bootstrap-switch.js
+++ b/static/js/bootstrap-switch.js
@@ -75,7 +75,7 @@
               .attr('for', $element.find(inputSelector).attr('id'));
 
             if (icon) {
-              $label.html('<i class="icon icon-' + icon + '"></i>');
+              $label.html('<i class="icon ' + icon + '"></i>');
             }
 
             $div = $element.find(inputSelector).wrap($('<div>')).parent().data('animated', false);


### PR DESCRIPTION
data-icon is used by many css fonts like font awesome or css themes like flat-ui and others, using data-icon adds unexpected content because of the css rule `[data-icon]:before {content: attr(data-icon);}`
