### PR TITLE
Fixes minor UI bug with 2px border

### DIFF
--- a/static/stylesheets/bootstrap-switch.css
+++ b/static/stylesheets/bootstrap-switch.css
@@ -140,6 +140,12 @@
 
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
 }
+.has-switch .switch-on label {
+  border-right: none;
+}
+.has-switch .switch-off label {
+  border-left: none;
+}
 .has-switch label:hover,
 .has-switch label:focus,
 .has-switch label:active,


### PR DESCRIPTION
There's two 1px adjacent borders, depending on which side the switch is on. Just hide the extra border, depending on which side we're on.
