### PR TITLE
Fixed dragging handle remaining stucked until mouseleave

### DIFF
--- a/static/js/bootstrap-switch.js
+++ b/static/js/bootstrap-switch.js
@@ -209,7 +209,7 @@
                   e.preventDefault();
                   e.stopImmediatePropagation();
 
-                  $this.unbind('mouseleave');
+                  $this.unbind('mouseleave mousemove');
                   $this.trigger('mouseup');
 
                   $myInputBox.prop('checked', !(parseInt($this.parent().css('left')) < -25)).trigger('change');
@@ -219,7 +219,7 @@
                   e.stopImmediatePropagation();
                   e.preventDefault();
 
-                  $(this).unbind('mousemove');
+                  $(this).trigger('mouseleave');
                 });
               }
             });


### PR DESCRIPTION
At the moment (on Chrome 29 at least) if you are dragging the handle and you release the mouse the handle stays there, not returning to one of the sides of the switch. It goes to the right position only on mouseleave.

The second commit fixes this issue, the other one is just simple refactoring and cleaning.
