### PR TITLE
Prevent re-initializing of switch.

### DIFF
--- a/static/js/bootstrap-switch.js
+++ b/static/js/bootstrap-switch.js
@@ -35,6 +35,9 @@
               , icon = false
               , textLabel = false;
 
+            if ($element.hasClass('has-switch'))
+                return true;
+
             $.each(['switch-mini', 'switch-small', 'switch-large'], function (i, el) {
               if (classes.indexOf(el) >= 0)
                 myClasses = el;


### PR DESCRIPTION
Creating an application that uses Bootstrap Carousel to move between views.  The first view contains a checkbox (switch) which was initialized upon page load.  When moving to a new view, also containing a switch, the first switch is re-initialized, resulting in stacked switches.   (Our markup places bootstrap.js in the view being loaded, not the base page.)
