### PR TITLE
Make dependent jQuery version at least 1.9.0

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,7 @@
     "examples"
   ],
   "dependencies": {
-    "jquery": "~1.9.0"
+    "jquery": ">=1.9.0"
   },
   "scripts": [
     "static/js/bootstrap-switch.js"


### PR DESCRIPTION
Make dependent jQuery version at least 1.9.0. Instead of relying precisely on that version. The later makes it hard to use jQuery 2.0 for example.
