### PR TITLE
Make dependent jQuery version at least 1.9.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "examples"
   ],
   "dependencies": {
-    "jquery": "~1.9.0"
+    "jquery": ">=1.9.0"
   }
 }
 


### PR DESCRIPTION
Make dependent jQuery version at least 1.9.0. Instead of relying precisely on that version. The later makes it hard to use jQuery 2.0 for example.
