### PR TITLE
Add missing comma to bower file.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "description" : "Unofficial bootstrap switch",
   "version": "1.9.0",
   "main": [
-    "build/js/bootstrap-switch.js"
+    "build/js/bootstrap-switch.js",
     "build/css/bootstrap3/bootstrap-switch.css"
   ],
   "ignore": [


### PR DESCRIPTION
Bower is failing to install your repository right now, and giving this error:

```
bower bootstrap-switch#*                  EMALFORMED Failed to read /tmp/kyrsten.kelly/bower/bootstrap-switch-11408-LhNux7/bower.json

Additional error details:
Unexpected string
```

I believe this missing comma is the issue.
