### PR TITLE
Moves Bootstrap Switch to be importable without mixins and variables

### DIFF
--- a/src/less/bootstrap2/base.less
+++ b/src/less/bootstrap2/base.less
@@ -1,0 +1,3 @@
+@import "variables";
+@import "mixins";
+@import "bootstrap-switch";

--- a/src/less/bootstrap2/bootstrap-switch.less
+++ b/src/less/bootstrap2/bootstrap-switch.less
@@ -1,6 +1,3 @@
-@import "variables";
-@import "mixins";
-
 .has-switch {
   display: inline-block;
   cursor: pointer;
@@ -181,3 +178,4 @@
     }
   }
 }
+


### PR DESCRIPTION
- Allow a user to import the bootstrap-switch less without variables or mixins
- Use base less file to import with both already
