### PR TITLE
fix(bower): bower.json as a proper json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,9 +10,9 @@
     "docs",
     "test",
     "CNAME",
-    "composer.json"
-    "CONTRIBUTING.md"
-    "gulpfile.js"
+    "composer.json",
+    "CONTRIBUTING.md",
+    "gulpfile.js",
     "index.html"
   ],
   "dependencies": {


### PR DESCRIPTION
`bower install bootstrap-switch#90857176abf48316e69673b853200a40b1356b96` didn't work because of syntax errors in the `bower.json` file.
