### PR TITLE
Toggle switch when clicking label (and not dragging)

### DIFF
--- a/src/coffee/bootstrap-switch.coffee
+++ b/src/coffee/bootstrap-switch.coffee
@@ -317,7 +317,12 @@ do ($ = window.jQuery, window) ->
 
           @drag = false
           @$element
-          .prop("checked", parseInt(@$container.css("margin-left"), 10) > -(@$container.width() / 6))
+          .prop("checked",
+            if @$container.prop("style").marginLeft == ""
+              !@$element.prop 'checked'
+            else
+              parseInt(@$container.css("margin-left"), 10) > -(@$container.width() / 6)
+          )
           .trigger "change.bootstrapSwitch"
           @$container.css "margin-left", ""
           @$wrapper.addClass "#{@options.baseClass}-animate" if @options.animate


### PR DESCRIPTION
This resolves #304 which is a feature I also wanted and would say is expected behaviour of toggle switches. When the mouse is released from a click on the label element then if the label has not been dragged at all it presumes it is a simple click and triggers a toggle of the switch. All other behaviour such as dragging still works as before.
