### PR TITLE
fix: always trigger the switchChange event after a change event

### DIFF
--- a/src/coffee/bootstrap-switch.coffee
+++ b/src/coffee/bootstrap-switch.coffee
@@ -376,7 +376,8 @@ do ($ = window.jQuery, window) ->
               .not(@$element)
               .prop("checked", false)
               .trigger "change.bootstrapSwitch", true
-            @$element.trigger "switchChange.bootstrapSwitch", [state]
+          
+          @$element.trigger "switchChange.bootstrapSwitch", [state]
 
         "focus.bootstrapSwitch": (e) =>
           e.preventDefault()


### PR DESCRIPTION
With 2 or more radio buttons, a change to the first radio button propagates correctly, while the change to the second one won't (as it is always skipped). This fixes it by propagating `switchChange.bootstrapSwitch` after every `change.bootstrapSwitch`.

Everything else keeps working.

Same as #349 but from the latest `develop` branch.
This is also needed to close https://github.com/frapontillo/angular-bootstrap-switch/issues/46.
