### PR TITLE
documentation correction - on/off label -> text

### DIFF
--- a/documentation-2.html
+++ b/documentation-2.html
@@ -129,14 +129,14 @@
                 <td>null</td>
               </tr>
               <tr>
-                <td>on-label</td>
+                <td>on-text</td>
                 <td>String</td>
                 <td>Text of the left side of the switch</td>
                 <td>String</td>
                 <td>'ON'</td>
               </tr>
               <tr>
-                <td>off-label</td>
+                <td>off-text</td>
                 <td>String</td>
                 <td>Text of the right side of the switch</td>
                 <td>String</td>

--- a/src/docs/jade/documentation-2.jade
+++ b/src/docs/jade/documentation-2.jade
@@ -69,13 +69,13 @@ block content
             td 'primary', 'info', 'success', 'warning', 'danger', 'default'
             td null
           tr
-            td on-label
+            td on-text
             td String
             td Text of the left side of the switch
             td String
             td 'ON'
           tr
-            td off-label
+            td off-text
             td String
             td Text of the right side of the switch
             td String


### PR DESCRIPTION
Changing labels on switch is done via data-on-text and data-off-text. Not as documentation says with "labels".
