### PR TITLE
Fixing file path for css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
       "basePath": "/dist/",
       "files": [
         "*.js",
-        "bootstrap3/*.css",
-        "bootstrap2/*.css"
+        "css/bootstrap3/*.css",
+        "css/bootstrap2/*.css"
       ]
     }
   ]


### PR DESCRIPTION
They were under a css folder under dist in the npm release
