### PR TITLE
Use SPDX license identifier

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "bootstrap-switch",
   "description": "Turn checkboxes and radio buttons into toggle switches.",
   "version": "3.3.2",
+  "license": "Apache-2.0",
   "main": [
     "./dist/js/bootstrap-switch.js",
     "./dist/css/bootstrap3/bootstrap-switch.css"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "git://github.com/nostalgiaz/bootstrap-switch.git"
   },
   "bugs": "https://github.com/nostalgiaz/bootstrap-switch/issues",
-  "license": "Apache Version 2",
+  "license": "Apache-2.0",
   "readmeFilename": "README.md",
   "devDependencies": {
     "browser-sync": "^2.6.4",


### PR DESCRIPTION
Otherwise it is rejected by http://www.webjars.org/npm
