### PR TITLE
Fix width issue with jQuery 3 + IE11.

### DIFF
--- a/src/coffee/bootstrap-switch.coffee
+++ b/src/coffee/bootstrap-switch.coffee
@@ -332,8 +332,8 @@ do ($ = window.jQuery, window) ->
         if width < handleWidth then handleWidth else width
 
       # get handle and label widths
-      @_handleWidth = @$on.outerWidth()
-      @_labelWidth = @$label.outerWidth()
+      @_handleWidth = Math.round @$on.outerWidth()
+      @_labelWidth = Math.round @$label.outerWidth()
 
       # set container and wrapper widths
       @$container.width (@_handleWidth * 2) + @_labelWidth


### PR DESCRIPTION
JQuery 3 doesn't round the results of `width` see https://github.com/jquery/jquery/issues/3193. This causes it not to display property in IE11. Related to #591