### PR TITLE
Added redraw() method.

### DIFF
--- a/src/js/bootstrap-switch.js
+++ b/src/js/bootstrap-switch.js
@@ -549,6 +549,12 @@ class BootstrapSwitch {
     return this.$element;
   }
 
+  redraw() {
+    this.destroy();
+    this.$element.bootstrapSwitch(this.options);
+    return this.$element;
+  }
+
   destroy() {
     const $form = this.$element.closest('form');
     if ($form.length) {


### PR DESCRIPTION
Help users that need to redraw/refresh the switcher due to init width issues when parent isn't visible, keeping the original options. Usage: $('#element').bootstrapSwitch('redraw');