### PR TITLE
Fix wrapper classes

### DIFF
--- a/src/js/bootstrap-switch.js
+++ b/src/js/bootstrap-switch.js
@@ -12,7 +12,7 @@ function getClasses(options, id) {
     indeterminate ? 'indeterminate' : undefined,
     inverse ? 'inverse' : undefined,
     id ? `id-${id}` : undefined,
-  ].filter(v => v == null);
+  ].filter(v => v != null);
 }
 
 


### PR DESCRIPTION
Additional wrapper classes (based on options) were being generated by filtering out any option with a value.
As a result the only option classes being added were `bootstrap-switch-undefined` and `bootstrap-switch-null`.
Changed `getClasses()` to return only options whose values are **not** null.